### PR TITLE
[Kanban] chage path of html files and overlapping logic

### DIFF
--- a/client/src/config/path.mjs
+++ b/client/src/config/path.mjs
@@ -1,5 +1,5 @@
 export const PATH = {
-  main_page: 'client/src/apps/kanban/index.html',
-  login_page: 'client/src/apps/login/index.html',
+  main_page: '/home/linegu/kanban/Kanban-Board/client/src/apps/kanban/index.html',
+  login_page: '/home/linegu/kanban/Kanban-Board/client/src/apps/login/index.html',
   server_url: 'http://101.101.217.111:8080',
 };

--- a/server/src/services/user.js
+++ b/server/src/services/user.js
@@ -87,6 +87,9 @@ const userService = {
   async getUserData(userEmail) {
     try {
       const userId = await userModel.getUserId(userEmail);
+      if (!userId) {
+        return false;
+      }
       const userData = await userModel.getUserData(userId);
       return userData;
     } catch (err) {


### PR DESCRIPTION
html파일의 경로를 변경해주고 아이디 중복 검사 로직의 틀린 점을 바로 잡았다.